### PR TITLE
add script to pyproject.toml

### DIFF
--- a/deepseek_engineer_entrypoint.py
+++ b/deepseek_engineer_entrypoint.py
@@ -1,0 +1,10 @@
+import runpy
+import os
+
+def main():
+    # Run the actual script file
+    script_path = os.path.join(os.path.dirname(__file__), 'deepseek-eng.py')
+    runpy.run_path(script_path, run_name='__main__')
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "rich>=13.9.4",
 ]
+
+[project.scripts]
+deepseek-engineer = "deepseek_engineer_entrypoint:main"


### PR DESCRIPTION
In order to install this as a "proper" package (via nixpkgs), I needed to:
- add it as script to `pyproject.toml`
- and an entrypoint matching python module naming conventions (no hyphens), and instead of renaming I thought to create a separate entrypoint file is better, but I'm not so much into python stuff :tipping_hand_man: 